### PR TITLE
CMS paging and image upload bugfix

### DIFF
--- a/src/data-providers/createDataProviderUsingConfiguredConnectors.js
+++ b/src/data-providers/createDataProviderUsingConfiguredConnectors.js
@@ -35,14 +35,14 @@ define([
 	}
 
 	function getFolderContents (options, browseContextDocumentId, targetFolder, noCache, hierarchyItems, offset) {
-        return configuredBrowseConnector.browse(
+		return configuredBrowseConnector.browse(
 			browseContextDocumentId,
 			options.assetTypes,
 			options.resultTypes,
 			targetFolder.id,
-            options.query || null,
-            null, 
-            offset,
+			options.query || null,
+			null,
+			offset,
 			noCache
 		)
 			.then(function (result) {
@@ -52,8 +52,8 @@ define([
 				);
 
 				return {
-                    hierarchyItems: newHierarchyItems,
-                    totalItemCount: result.totalItemCount,
+					hierarchyItems: newHierarchyItems,
+					totalItemCount: result.totalItemCount,
 					items: result.items.map(function (item) {
 						if (!item.metadata) {
 							return item;
@@ -108,7 +108,7 @@ define([
 			 * @param {object} targetFolder
 			 * @param {boolean} noCache
 			 * @param {object[]} hierarchyItems
-             * @param {number} offset
+			 * @param {number} offset
 			 *
 			 * @return {Promise<{
 			 *   hierarchyItems: string[]

--- a/src/data-providers/createDataProviderUsingConfiguredConnectors.js
+++ b/src/data-providers/createDataProviderUsingConfiguredConnectors.js
@@ -34,15 +34,15 @@ define([
 		return updatedFolderHierarchy;
 	}
 
-	function getFolderContents (options, browseContextDocumentId, targetFolder, noCache, hierarchyItems) {
-		return configuredBrowseConnector.browse(
+	function getFolderContents (options, browseContextDocumentId, targetFolder, noCache, hierarchyItems, offset) {
+        return configuredBrowseConnector.browse(
 			browseContextDocumentId,
 			options.assetTypes,
 			options.resultTypes,
 			targetFolder.id,
-			options.query || null,
-			null,
-			null,
+            options.query || null,
+            null, 
+            offset,
 			noCache
 		)
 			.then(function (result) {
@@ -52,7 +52,8 @@ define([
 				);
 
 				return {
-					hierarchyItems: newHierarchyItems,
+                    hierarchyItems: newHierarchyItems,
+                    totalItemCount: result.totalItemCount,
 					items: result.items.map(function (item) {
 						if (!item.metadata) {
 							return item;
@@ -107,14 +108,15 @@ define([
 			 * @param {object} targetFolder
 			 * @param {boolean} noCache
 			 * @param {object[]} hierarchyItems
+             * @param {number} offset
 			 *
 			 * @return {Promise<{
 			 *   hierarchyItems: string[]
 			 *   items: { id: string, label: string, icon: string, isDisabled: Boolean, externalUrl: string }[]
 			 * }>}
 			 */
-			getFolderContents: function (browseContextDocumentId, targetFolder, noCache, hierarchyItems) {
-				return getFolderContents(options, browseContextDocumentId, targetFolder, noCache, hierarchyItems);
+			getFolderContents: function (browseContextDocumentId, targetFolder, noCache, hierarchyItems, offset) {
+				return getFolderContents(options, browseContextDocumentId, targetFolder, noCache, hierarchyItems, offset);
 			},
 
 			/**

--- a/src/documents/DocumentBrowserModal.jsx.js
+++ b/src/documents/DocumentBrowserModal.jsx.js
@@ -175,9 +175,9 @@ class DocumentBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
-            onItemSelect,
-            onPageBackward,
-            onPageForward,
+			onItemSelect,
+			onPageBackward,
+			onPageForward,
 			onViewModeChange,
 			refreshItems,
 			renderModalBodyToolbar,
@@ -244,10 +244,10 @@ class DocumentBrowserModal extends Component {
 						</ModalContent>
 					</ModalContent>
 
-                    <ModalBrowserPagination
-                        handlePageBackward={onPageBackward}
-                        handlePageForward={onPageForward}
-                    />
+					<ModalBrowserPagination
+						handlePageBackward={onPageBackward}
+						handlePageForward={onPageForward}
+					/>
 
 				</ModalBody>
 

--- a/src/documents/DocumentBrowserModal.jsx.js
+++ b/src/documents/DocumentBrowserModal.jsx.js
@@ -21,6 +21,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserPagination from '../shared/ModalBrowserPagination.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
@@ -173,7 +174,9 @@ class DocumentBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
-			onItemSelect,
+            onItemSelect,
+            onPageBackward,
+            onPageForward,
 			onViewModeChange,
 			refreshItems,
 			renderModalBodyToolbar,
@@ -239,6 +242,12 @@ class DocumentBrowserModal extends Component {
 							)}
 						</ModalContent>
 					</ModalContent>
+
+                    <ModalBrowserPagination
+                        handlePageBackward={onPageBackward}
+                        handlePageForward={onPageForward}
+                    />
+
 				</ModalBody>
 
 				<ModalFooter>

--- a/src/documents/DocumentTemplateBrowserModal.jsx.js
+++ b/src/documents/DocumentTemplateBrowserModal.jsx.js
@@ -20,6 +20,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserPagination from '../shared/ModalBrowserPagination.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
@@ -132,7 +133,9 @@ class DocumentTemplateBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
-			onItemSelect,
+            onItemSelect,
+            onPageBackward,
+            onPageForward,
 			onViewModeChange,
 			refreshItems,
 			request,
@@ -194,6 +197,12 @@ class DocumentTemplateBrowserModal extends Component {
 								)}
 						</ModalContent>
 					</ModalContent>
+
+                    <ModalBrowserPagination
+                        handlePageBackward={onPageBackward}
+                        handlePageForward={onPageForward}
+                    />
+
 				</ModalBody>
 
 				<ModalFooter>

--- a/src/documents/DocumentTemplateBrowserModal.jsx.js
+++ b/src/documents/DocumentTemplateBrowserModal.jsx.js
@@ -137,9 +137,9 @@ class DocumentTemplateBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
-            onItemSelect,
-            onPageBackward,
-            onPageForward,
+			onItemSelect,
+			onPageBackward,
+			onPageForward,
 			onViewModeChange,
 			refreshItems,
 			request,
@@ -203,10 +203,10 @@ class DocumentTemplateBrowserModal extends Component {
 						</ModalContent>
 					</ModalContent>
 
-                    <ModalBrowserPagination
-                        handlePageBackward={onPageBackward}
-                        handlePageForward={onPageForward}
-                    />
+					<ModalBrowserPagination
+						handlePageBackward={onPageBackward}
+						handlePageForward={onPageForward}
+					/>
 
 				</ModalBody>
 

--- a/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
+++ b/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
@@ -21,6 +21,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserPagination from '../shared/ModalBrowserPagination.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
@@ -132,7 +133,9 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
-			onItemSelect,
+            onItemSelect,
+            onPageBackward,
+            onPageForward,
 			onViewModeChange,
 			refreshItems,
 			request,
@@ -196,6 +199,12 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 							)}
 						</ModalContent>
 					</ModalContent>
+
+                    <ModalBrowserPagination
+                        handlePageBackward={onPageBackward}
+                        handlePageForward={onPageForward}
+                    />
+
 				</ModalBody>
 
 				<ModalFooter>

--- a/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
+++ b/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
@@ -137,9 +137,9 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
-            onItemSelect,
-            onPageBackward,
-            onPageForward,
+			onItemSelect,
+			onPageBackward,
+			onPageForward,
 			onViewModeChange,
 			refreshItems,
 			request,
@@ -205,10 +205,10 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 						</ModalContent>
 					</ModalContent>
 
-                    <ModalBrowserPagination
-                        handlePageBackward={onPageBackward}
-                        handlePageForward={onPageForward}
-                    />
+					<ModalBrowserPagination
+						handlePageBackward={onPageBackward}
+						handlePageForward={onPageForward}
+					/>
 
 				</ModalBody>
 

--- a/src/documents/FolderBrowserModal.jsx.js
+++ b/src/documents/FolderBrowserModal.jsx.js
@@ -19,6 +19,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserPagination from '../shared/ModalBrowserPagination.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
 const stateLabels = {
@@ -93,7 +94,9 @@ class FolderBrowserModal extends Component {
 			data: { browseContextDocumentId, modalPrimaryButtonLabel, modalTitle },
 			hierarchyItems,
 			items,
-			onItemSelect,
+            onItemSelect,
+            onPageBackward,
+            onPageForward,
 			onViewModeChange,
 			refreshItems,
 			request,
@@ -141,6 +144,12 @@ class FolderBrowserModal extends Component {
 							/>
 						</ModalContent>
 					</ModalContent>
+
+                    <ModalBrowserPagination
+                        handlePageBackward={onPageBackward}
+                        handlePageForward={onPageForward}
+                    />
+
 				</ModalBody>
 
 				<ModalFooter>

--- a/src/documents/FolderBrowserModal.jsx.js
+++ b/src/documents/FolderBrowserModal.jsx.js
@@ -94,9 +94,9 @@ class FolderBrowserModal extends Component {
 			data: { browseContextDocumentId, modalPrimaryButtonLabel, modalTitle },
 			hierarchyItems,
 			items,
-            onItemSelect,
-            onPageBackward,
-            onPageForward,
+			onItemSelect,
+			onPageBackward,
+			onPageForward,
 			onViewModeChange,
 			refreshItems,
 			request,
@@ -145,10 +145,10 @@ class FolderBrowserModal extends Component {
 						</ModalContent>
 					</ModalContent>
 
-                    <ModalBrowserPagination
-                        handlePageBackward={onPageBackward}
-                        handlePageForward={onPageForward}
-                    />
+					<ModalBrowserPagination
+						handlePageBackward={onPageBackward}
+						handlePageForward={onPageForward}
+					/>
 
 				</ModalBody>
 

--- a/src/images/ImageBrowserModal.jsx.js
+++ b/src/images/ImageBrowserModal.jsx.js
@@ -22,6 +22,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserPagination from '../shared/ModalBrowserPagination.jsx';
 import ModalBrowserUploadButton from '../shared/ModalBrowserUploadButton.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
@@ -138,12 +139,14 @@ class ImageBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemSelect,
-			onUploadFileSelect,
+            onPageBackward,
+            onPageForward,
+            onUploadFileSelect,
 			onViewModeChange,
 			refreshItems,
 			request,
 			selectedItem,
-			viewMode
+            viewMode
 		} = this.props;
 		const hasHierarchyItems = hierarchyItems.length > 0;
 
@@ -218,9 +221,15 @@ class ImageBrowserModal extends Component {
 										stateLabels={stateLabels}
 									/>
 								</ModalContent>
-							)}
+                            )}
 						</ModalContent>
 					</ModalContent>
+
+                    <ModalBrowserPagination
+                        handlePageBackward={onPageBackward}
+                        handlePageForward={onPageForward}
+                    />
+
 				</ModalBody>
 
 				<ModalFooter>

--- a/src/images/ImageBrowserModal.jsx.js
+++ b/src/images/ImageBrowserModal.jsx.js
@@ -139,14 +139,14 @@ class ImageBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemSelect,
-            onPageBackward,
-            onPageForward,
-            onUploadFileSelect,
+			onPageBackward,
+			onPageForward,
+			onUploadFileSelect,
 			onViewModeChange,
 			refreshItems,
 			request,
 			selectedItem,
-            viewMode
+			viewMode
 		} = this.props;
 		const hasHierarchyItems = hierarchyItems.length > 0;
 
@@ -225,10 +225,10 @@ class ImageBrowserModal extends Component {
 						</ModalContent>
 					</ModalContent>
 
-                    <ModalBrowserPagination
-                        handlePageBackward={onPageBackward}
-                        handlePageForward={onPageForward}
-                    />
+					<ModalBrowserPagination
+						handlePageBackward={onPageBackward}
+						handlePageForward={onPageForward}
+					/>
 
 				</ModalBody>
 

--- a/src/shared/ModalBrowserPagination.jsx.js
+++ b/src/shared/ModalBrowserPagination.jsx.js
@@ -1,7 +1,8 @@
 import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
-import { ModalBodyToolbar, TextLink } from 'fds/components';
+import { Button, Flex } from 'fds/components';
+import { paddingTop } from 'fds/system';
 
 import t from 'fontoxml-localization/t';
 
@@ -22,25 +23,25 @@ class ModalBrowserPagination extends Component {
 
 		if (handlePageBackward && handlePageForward) {
 			return (
-				<ModalBodyToolbar justifyContent='space-between'>
-					<TextLink label={t('Previous')} onClick={handlePageBackward} />
-					<TextLink label={t('Next')} onClick={handlePageForward} />
-				</ModalBodyToolbar>
+				<Flex justifyContent='space-between' flex='0 0 auto' applyCss={[paddingTop('m')]}>
+					<Button icon='chevron-left' label={t('Previous')} onClick={handlePageBackward} />
+					<Button iconAfter='chevron-right' label={t('Next')} onClick={handlePageForward} />
+				</Flex>
 			);
 		}
 
 		if (handlePageForward) {
 			return (
-				<ModalBodyToolbar justifyContent='flex-end'>
-					<TextLink label={t('Next')} onClick={handlePageForward} />
-				</ModalBodyToolbar>
+				<Flex justifyContent='flex-end' flex='0 0 auto' applyCss={[paddingTop('m')]}>
+					<Button iconAfter='chevron-right' label={t('Next')} onClick={handlePageForward} />
+				</Flex>
 			);
 		}
 
 		return (
-			<ModalBodyToolbar>
-				<TextLink label={t('Previous')} onClick={handlePageBackward} />
-			</ModalBodyToolbar>
+			<Flex justifyContent='flex-start' flex='0 0 auto' applyCss={[paddingTop('m')]}>
+				<Button icon='chevron-left' label={t('Previous')} onClick={handlePageBackward} />
+			</Flex>
 		);
 	}
 }

--- a/src/shared/ModalBrowserPagination.jsx.js
+++ b/src/shared/ModalBrowserPagination.jsx.js
@@ -7,42 +7,42 @@ import t from 'fontoxml-localization/t';
 
 class ModalBrowserPagination extends Component {
 
-    static propTypes = {
-        handlePageBackward: PropTypes.func,
-        handlePageForward: PropTypes.func
-    };
+	static propTypes = {
+		handlePageBackward: PropTypes.func,
+		handlePageForward: PropTypes.func
+	};
 
-    render() {
+	render() {
 
-        const { handlePageBackward, handlePageForward } = this.props;
+		const { handlePageBackward, handlePageForward } = this.props;
 
-        if (!handlePageBackward && !handlePageForward) {
-            return null;
-        }
+		if (!handlePageBackward && !handlePageForward) {
+			return null;
+		}
 
-        if (handlePageBackward && handlePageForward) {
-            return (
-                <ModalBodyToolbar justifyContent='space-between'>
-                    <TextLink label={t('Previous')} onClick={handlePageBackward} />
-                    <TextLink label={t('Next')} onClick={handlePageForward} />
-                </ModalBodyToolbar>
-            );
-        }
+		if (handlePageBackward && handlePageForward) {
+			return (
+				<ModalBodyToolbar justifyContent='space-between'>
+					<TextLink label={t('Previous')} onClick={handlePageBackward} />
+					<TextLink label={t('Next')} onClick={handlePageForward} />
+				</ModalBodyToolbar>
+			);
+		}
 
-        if (handlePageForward) {
-            return (
-                <ModalBodyToolbar justifyContent='flex-end'>
-                    <TextLink label={t('Next')} onClick={handlePageForward} />
-                </ModalBodyToolbar>
-            );
-        }
+		if (handlePageForward) {
+			return (
+				<ModalBodyToolbar justifyContent='flex-end'>
+					<TextLink label={t('Next')} onClick={handlePageForward} />
+				</ModalBodyToolbar>
+			);
+		}
 
-        return (
-            <ModalBodyToolbar>
-                <TextLink label={t('Previous')} onClick={handlePageBackward} />
-            </ModalBodyToolbar>
-        );
-    }
+		return (
+			<ModalBodyToolbar>
+				<TextLink label={t('Previous')} onClick={handlePageBackward} />
+			</ModalBodyToolbar>
+		);
+	}
 }
 
 export default ModalBrowserPagination;

--- a/src/shared/ModalBrowserPagination.jsx.js
+++ b/src/shared/ModalBrowserPagination.jsx.js
@@ -1,0 +1,48 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+import { ModalBodyToolbar, TextLink } from 'fds/components';
+
+import t from 'fontoxml-localization/t';
+
+class ModalBrowserPagination extends Component {
+
+    static propTypes = {
+        handlePageBackward: PropTypes.func,
+        handlePageForward: PropTypes.func
+    };
+
+    render() {
+
+        const { handlePageBackward, handlePageForward } = this.props;
+
+        if (!handlePageBackward && !handlePageForward) {
+            return null;
+        }
+
+        if (handlePageBackward && handlePageForward) {
+            return (
+                <ModalBodyToolbar justifyContent='space-between'>
+                    <TextLink label={t('Previous')} onClick={handlePageBackward} />
+                    <TextLink label={t('Next')} onClick={handlePageForward} />
+                </ModalBodyToolbar>
+            );
+        }
+
+        if (handlePageForward) {
+            return (
+                <ModalBodyToolbar justifyContent='flex-end'>
+                    <TextLink label={t('Next')} onClick={handlePageForward} />
+                </ModalBodyToolbar>
+            );
+        }
+
+        return (
+            <ModalBodyToolbar>
+                <TextLink label={t('Previous')} onClick={handlePageBackward} />
+            </ModalBodyToolbar>
+        );
+    }
+}
+
+export default ModalBrowserPagination;

--- a/src/withModularBrowserCapabilities.jsx.js
+++ b/src/withModularBrowserCapabilities.jsx.js
@@ -7,17 +7,23 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 		return class ModularBrowser extends Component {
 			dataProvider = dataProviders.get(this.props.data.dataProviderName);
 			initialSelectedItem = {};
-			isMountedInDOM = true;
+            isMountedInDOM = true;
 
 			state = {
-				// Errors that occured when loading a item, for if the items are only loaded in the preview.
+				// Errors that occurred when loading a item, for if the items are only loaded in the preview.
 				cachedErrorByRemoteId: {},
 
-				// Contains the items that the user can choose from
+                // The currently set contextNodeId, if any.
+                currentBrowseContextNodeId: null,
+
+                // Contains the items that the user can choose from
 				hierarchyItems: [],
 
 				// Contains the items that the user can choose from
-				items: [],
+                items: [],
+
+                // Paging option; The zero-based offset from on which to get results.
+                offset: 0,
 
 				// Contains information on the current/last known request
 				// { type: fileLoad|search|browse|upload, ?query, ?error, ?resultCount }
@@ -25,6 +31,9 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 
 				// The item that is previewed and would be submitted if the user continues
 				selectedItem: null,
+
+                // the total number of items available on the CMS
+                totalItemCount: null,
 
 				// Contains information for the viewMode, for example list or grid
 				viewMode: initialViewMode
@@ -67,6 +76,24 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 				}
 			};
 
+            onPageBackward = () => {
+                const { offset, items } = this.state;
+
+                const nextOffset = this.state.offset - items.length;
+
+                this.setState({
+                    offset: nextOffset > 0 ? nextOffset : 0,
+                });
+            };
+
+            onPageForward = () => {
+                const { offset, items } = this.state;
+
+                this.setState({
+                    offset: offset + items.length,
+                });
+            };
+
 			// Used to update the items with a browse callback
 			refreshItems = (browseContextDocumentId, folderToLoad, noCache) => {
 				const { determineAndHandleSubmitButtonDisabledState } = this.props.data;
@@ -77,13 +104,14 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 				return this.dataProvider
 					.getFolderContents(
 						browseContextDocumentId,
-						folderToLoad,
+                        folderToLoad,
 						noCache,
-						this.state.hierarchyItems
+						this.state.hierarchyItems,
+                        this.state.offset
 					)
 					.then(
 						result => {
-							if (!this.isMountedInDOM) {
+                            if (!this.isMountedInDOM) {
 								return [];
 							}
 							// Because of jump in the tree with browse context document id,
@@ -106,8 +134,10 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 							}
 
 							this.setState({
+                                currentBrowseContextNodeId: browseContextDocumentId,
 								selectedItem: newSelectedItem,
-								items: result.items,
+                                items: result.items,
+                                totalItemCount: result.totalItemCount,
 								hierarchyItems: result.hierarchyItems,
 								request: {}
 							});
@@ -167,13 +197,14 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 
 				this.dataProvider.upload(folderWithUploadedFile.id, selectedFiles).then(
 					uploadedItem => {
-						return this.refreshItems(
+                        return this.refreshItems(
 							browseContextDocumentId,
 							folderWithUploadedFile,
 							true
 						).then(items => {
 							this.onItemSelect(
-								items.find(item => item.id === uploadedItem.id) || null
+                                // ensure the newly uploaded item is always selected
+								items.find(item => item.id === uploadedItem.id) || uploadedItem || null
 							);
 						});
 					},
@@ -197,7 +228,15 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 				this.isMountedInDOM && this.setState({ viewMode: viewMode });
 
 			render() {
-				const { hierarchyItems, items, request, selectedItem, viewMode } = this.state;
+				const {
+                    hierarchyItems,
+                    items,
+                    offset,
+                    request,
+                    selectedItem,
+                    totalItemCount,
+                    viewMode
+                } = this.state;
 
 				const props = {
 					...this.props,
@@ -207,17 +246,31 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 					items,
 					onItemIsErrored: this.onItemIsErrored,
 					onItemSelect: this.onItemSelect,
-					onInitialSelectedItemIdChange: this.onInitialSelectedItemIdChange,
+                    onInitialSelectedItemIdChange: this.onInitialSelectedItemIdChange,
+                    onPageForward: offset + items.length < totalItemCount ? this.onPageForward : undefined,
+                    onPageBackward: offset > 0 ? this.onPageBackward : undefined,
 					onUploadFileSelect: this.onUploadFileSelect,
 					onViewModeChange: this.onViewModeChange,
 					refreshItems: this.refreshItems,
 					request,
 					selectedItem,
-					viewMode
+                    viewMode
 				};
 
 				return <WrappedComponent {...props} />;
 			}
+
+            componentDidUpdate(prevProps, prevState) {
+                if (prevState.offset != this.state.offset) {
+                    // perform paging
+
+                    const { hierarchyItems, currentBrowseContextNodeId } = this.state;
+
+                    const currentFolder = hierarchyItems[hierarchyItems.length - 1];
+
+                    this.refreshItems(currentBrowseContextNodeId, currentFolder);
+                }
+            }
 
 			componentWillUnmount() {
 				this.isMountedInDOM = false;

--- a/src/withModularBrowserCapabilities.jsx.js
+++ b/src/withModularBrowserCapabilities.jsx.js
@@ -7,23 +7,23 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 		return class ModularBrowser extends Component {
 			dataProvider = dataProviders.get(this.props.data.dataProviderName);
 			initialSelectedItem = {};
-            isMountedInDOM = true;
+			isMountedInDOM = true;
 
 			state = {
 				// Errors that occurred when loading a item, for if the items are only loaded in the preview.
 				cachedErrorByRemoteId: {},
 
-                // The currently set contextNodeId, if any.
-                currentBrowseContextNodeId: null,
+				// The currently set contextNodeId, if any.
+				currentBrowseContextNodeId: null,
 
-                // Contains the items that the user can choose from
+				// Contains the items that the user can choose from
 				hierarchyItems: [],
 
 				// Contains the items that the user can choose from
-                items: [],
+				items: [],
 
-                // Paging option; The zero-based offset from on which to get results.
-                offset: 0,
+				// Paging option; The zero-based offset from on which to get results.
+				offset: 0,
 
 				// Contains information on the current/last known request
 				// { type: fileLoad|search|browse|upload, ?query, ?error, ?resultCount }
@@ -32,8 +32,8 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 				// The item that is previewed and would be submitted if the user continues
 				selectedItem: null,
 
-                // the total number of items available on the CMS
-                totalItemCount: null,
+				// the total number of items available on the CMS
+				totalItemCount: null,
 
 				// Contains information for the viewMode, for example list or grid
 				viewMode: initialViewMode
@@ -92,23 +92,23 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 				}
 			};
 
-            onPageBackward = () => {
-                const { offset, items } = this.state;
+			onPageBackward = () => {
+				const { offset, items } = this.state;
 
-                const nextOffset = this.state.offset - items.length;
+				const nextOffset = this.state.offset - items.length;
 
-                this.setState({
-                    offset: nextOffset > 0 ? nextOffset : 0,
-                });
-            };
+				this.setState({
+					offset: nextOffset > 0 ? nextOffset : 0,
+				});
+			};
 
-            onPageForward = () => {
-                const { offset, items } = this.state;
+			onPageForward = () => {
+				const { offset, items } = this.state;
 
-                this.setState({
-                    offset: offset + items.length,
-                });
-            };
+				this.setState({
+					offset: offset + items.length,
+				});
+			};
 
 			// Used to update the items with a browse callback
 			refreshItems = (browseContextDocumentId, folderToLoad, noCache) => {
@@ -120,14 +120,14 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 				return this.dataProvider
 					.getFolderContents(
 						browseContextDocumentId,
-                        folderToLoad,
+						folderToLoad,
 						noCache,
 						this.state.hierarchyItems,
-                        this.state.offset
+						this.state.offset
 					)
 					.then(
 						result => {
-                            if (!this.isMountedInDOM) {
+							if (!this.isMountedInDOM) {
 								return [];
 							}
 							// Because of jump in the tree with browse context document id,
@@ -150,10 +150,10 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 							}
 
 							this.setState({
-                                currentBrowseContextNodeId: browseContextDocumentId,
+								currentBrowseContextNodeId: browseContextDocumentId,
 								selectedItem: newSelectedItem,
-                                items: result.items,
-                                totalItemCount: result.totalItemCount,
+								items: result.items,
+								totalItemCount: result.totalItemCount,
 								hierarchyItems: result.hierarchyItems,
 								request: {}
 							});
@@ -213,13 +213,13 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 
 				this.dataProvider.upload(folderWithUploadedFile.id, selectedFiles).then(
 					uploadedItem => {
-                        return this.refreshItems(
+						return this.refreshItems(
 							browseContextDocumentId,
 							folderWithUploadedFile,
 							true
 						).then(items => {
 							this.onItemSelect(
-                                // ensure the newly uploaded item is always selected
+								// ensure the newly uploaded item is always selected
 								items.find(item => item.id === uploadedItem.id) || uploadedItem || null
 							);
 						});
@@ -245,14 +245,14 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 
 			render() {
 				const {
-                    hierarchyItems,
-                    items,
-                    offset,
-                    request,
-                    selectedItem,
-                    totalItemCount,
-                    viewMode
-                } = this.state;
+					hierarchyItems,
+					items,
+					offset,
+					request,
+					selectedItem,
+					totalItemCount,
+					viewMode
+				} = this.state;
 
 				const props = {
 					...this.props,
@@ -263,31 +263,31 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 					onItemIsErrored: this.onItemIsErrored,
 					onItemIsLoaded: this.onItemIsLoaded,
 					onItemSelect: this.onItemSelect,
-                    onInitialSelectedItemIdChange: this.onInitialSelectedItemIdChange,
-                    onPageForward: offset + items.length < totalItemCount ? this.onPageForward : undefined,
-                    onPageBackward: offset > 0 ? this.onPageBackward : undefined,
+					onInitialSelectedItemIdChange: this.onInitialSelectedItemIdChange,
+					onPageForward: offset + items.length < totalItemCount ? this.onPageForward : undefined,
+					onPageBackward: offset > 0 ? this.onPageBackward : undefined,
 					onUploadFileSelect: this.onUploadFileSelect,
 					onViewModeChange: this.onViewModeChange,
 					refreshItems: this.refreshItems,
 					request,
 					selectedItem,
-                    viewMode
+					viewMode
 				};
 
 				return <WrappedComponent {...props} />;
 			}
 
-            componentDidUpdate(prevProps, prevState) {
-                if (prevState.offset != this.state.offset) {
-                    // perform paging
+			componentDidUpdate(prevProps, prevState) {
+				if (prevState.offset != this.state.offset) {
+					// perform paging
 
-                    const { hierarchyItems, currentBrowseContextNodeId } = this.state;
+					const { hierarchyItems, currentBrowseContextNodeId } = this.state;
 
-                    const currentFolder = hierarchyItems[hierarchyItems.length - 1];
+					const currentFolder = hierarchyItems[hierarchyItems.length - 1];
 
-                    this.refreshItems(currentBrowseContextNodeId, currentFolder);
-                }
-            }
+					this.refreshItems(currentBrowseContextNodeId, currentFolder);
+				}
+			}
 
 			componentWillUnmount() {
 				this.isMountedInDOM = false;


### PR DESCRIPTION
The CMS browser did not appear to perform any paging when the CMS responded with totalItemCount > items.length.

If a file was uploaded and upon refresh it was not found in the results, nothing would happen. The fix checks the current page of results for the new file and selects it, otherwise defaults to the uploaded file to ensure it will always be available.