### PR TITLE
Passthrough label and metadata of the selected item to the next operation step.

### DIFF
--- a/src/documents/DocumentBrowserModal.jsx.js
+++ b/src/documents/DocumentBrowserModal.jsx.js
@@ -50,7 +50,9 @@ const stateLabels = {
 function getSubmitModalData(itemToSubmit) {
 	return {
 		remoteDocumentId: itemToSubmit.id,
-		documentId: itemToSubmit.documentId
+		documentId: itemToSubmit.documentId,
+		label: itemToSubmit.label,
+		metadata: itemToSubmit.metadata
 	};
 }
 

--- a/src/documents/DocumentTemplateBrowserModal.jsx.js
+++ b/src/documents/DocumentTemplateBrowserModal.jsx.js
@@ -51,7 +51,8 @@ const stateLabels = {
 function getSubmitModalData(itemToSubmit) {
 	return {
 		remoteDocumentId: itemToSubmit.id,
-		label: itemToSubmit.label
+		label: itemToSubmit.label,
+		metadata: itemToSubmit.metadata
 	};
 }
 

--- a/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
+++ b/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
@@ -52,7 +52,9 @@ const stateLabels = {
 function getSubmitModalData(itemToSubmit) {
 	return {
 		documentId: itemToSubmit.documentId,
-		nodeId: itemToSubmit.nodeId
+		nodeId: itemToSubmit.nodeId,
+		label: itemToSubmit.label,
+		metadata: itemToSubmit.metadata
 	};
 }
 

--- a/src/images/ImageBrowserModal.jsx.js
+++ b/src/images/ImageBrowserModal.jsx.js
@@ -58,7 +58,9 @@ const uploadErrorMessages = {
 
 function getSubmitModalData(itemToSubmit) {
 	return {
-		selectedImageId: itemToSubmit.id
+		selectedImageId: itemToSubmit.id,
+		label: itemToSubmit.label,
+		metadata: itemToSubmit.metadata
 	};
 }
 

--- a/src/operations.json
+++ b/src/operations.json
@@ -89,6 +89,16 @@
 					"name": "nodeId",
 					"type": "NodeId",
 					"description": "The nodeId of the selected node."
+				},
+				{
+					"name": "label",
+					"type": "string",
+					"description": "The label of the selected document item."
+				},
+				{
+					"name": "metadata",
+					"type": "object",
+					"description": "The metadata of the selected document item."
 				}
 			]
 		},
@@ -185,6 +195,16 @@
 					"name": "selectedImageId",
 					"type": "AssetId",
 					"description": "The remoteId of the selected image."
+				},
+				{
+					"name": "label",
+					"type": "string",
+					"description": "The label of the selected image item."
+				},
+				{
+					"name": "metadata",
+					"type": "object",
+					"description": "The metadata of the selected image item."
 				}
 			]
 		},
@@ -288,6 +308,16 @@
 					"name": "remoteDocumentId",
 					"type": "RemoteDocumentId",
 					"description": "The remoteDocumentId of the selected document."
+				},
+				{
+					"name": "label",
+					"type": "string",
+					"description": "The label of the selected document item."
+				},
+				{
+					"name": "metadata",
+					"type": "object",
+					"description": "The metadata of the selected document item."
 				}
 			]
 		},
@@ -373,6 +403,16 @@
 					"name": "remoteDocumentId",
 					"type": "RemoteDocumentId",
 					"description": "The remoteDocumentId of the selected document template."
+				},
+				{
+					"name": "label",
+					"type": "string",
+					"description": "The label of the selected document item."
+				},
+				{
+					"name": "metadata",
+					"type": "object",
+					"description": "The metadata of the selected document item."
 				}
 			]
 		},
@@ -487,6 +527,16 @@
 					"name": "remoteDocumentId",
 					"type": "RemoteDocumentId",
 					"description": "(Open document) The remoteDocumentId of the selected document."
+				},
+				{
+					"name": "label",
+					"type": "string",
+					"description": "(Open document) The label of the selected document item."
+				},
+				{
+					"name": "metadata",
+					"type": "object",
+					"description": "(Open document) The metadata of the selected document item."
 				},
 				{
 					"name": "selectedDocumentTemplateId",


### PR DESCRIPTION
In some cases a next operation step needs the label and/or metadata from the browse item.

This change passes the label and metadata through out of the modal to the next step for the document, document template, document with link, and image modals.