### PR TITLE
Fix determineAndHandleSubmitButtonDisabledState.

### DIFF
--- a/src/withModularBrowserCapabilities.jsx.js
+++ b/src/withModularBrowserCapabilities.jsx.js
@@ -69,7 +69,7 @@ export default function withModularBrowserCapabilities(initialViewMode = null) {
 
 			// Used to update the items with a browse callback
 			refreshItems = (browseContextDocumentId, folderToLoad, noCache) => {
-				const { determineAndHandleSubmitButtonDisabledState } = this.props.data;
+				const { determineAndHandleSubmitButtonDisabledState } = this.props;
 				if (this.isMountedInDOM) {
 					this.setState({ request: { type: 'browse', busy: true } });
 				}


### PR DESCRIPTION
Determination of the submit button disable state was not done correctly in all cases.

### Steps to reproduce
* Open the a browse modal
* Select an item
* Browse to another folder
* Note the submit button being in an enabled state even if there is no item selected

### Root cause
When refreshing the items the `determineAndHandleSubmitButtonDisabledState` function was being retrieved from props.data, where it is not. Further along the function availability was checked, not found, and thus not executed resulting in the submit button's disabled state being kept in its enabled state. 

## Fix
When refreshing the items retrieve the `determineAndHandleSubmitButtonDisabledState` function is correctly obtained, where it is. Resulting in correctly determination of the submit button's disabled state.
