### PR TITLE
Implement optional fulltext search.

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ This browser can be used by adding the following operation step to your operatio
 * The elements which should be selectable by the user can be set by providing a `linkableElementsQuery`. This is an {@link XPathQuery}.
 * Use `dataProviderName` to override the default data provider properties.
 * When this browser is used to edit an existing link, the `documentId` and `nodeId` properties can be used to set the selection on the original document and element.
+* Use `enableSearch` to enable the fulltext search query field in the toolbar.
 * Use `insertOperationName` to disable the primary button based on the operation state.
 * The browser icon, title and primary button label can be set with the `modalIcon`, `modalTitle` and `modalPrimaryButtonLabel` respectively.
 
@@ -48,6 +49,7 @@ This browser can be used by adding the following operation step to your operatio
 
 * When this browser is being used to edit a reference to an existing image, the `selectedImageId` property can be used to set the selection on the original image.
 * Use `dataProviderName` to override the default data provider properties.
+* Use `enableSearch` to enable the fulltext search query field in the toolbar.
 * Use `insertOperationName` to disable the primary button based on the operation state.
 * The browser icon, title and primary button label can be set with the `modalIcon`, `modalTitle` and `modalPrimaryButtonLabel` respectively.
 
@@ -69,6 +71,7 @@ This browser can be used by adding the following operation step to your operatio
 
 * When this browser is being used to edit a reference to an existing document, the `documentId` property can be used to set the selection on the original document.
 * Use `dataProviderName` to override the default data provider properties.
+* Use `enableSearch` to enable the fulltext search query field in the toolbar.
 * Use `insertOperationName` to disable the primary button based on the operation state.
 * The browser icon, title and primary button label can be set with the `modalIcon`, `modalTitle` and `modalPrimaryButtonLabel` respectively.
 
@@ -95,6 +98,7 @@ This browser can be used by adding the following operation step to your operatio
 
 * Use `insertOperationName` to disable the primary button based on the operation state.
 * Use `dataProviderName` to override the default data provider properties.
+* Use `enableSearch` to enable the fulltext search query field in the toolbar.
 * The browser icon, title and primary button label can be set with the `modalIcon`, `modalTitle` and `modalPrimaryButtonLabel` respectively.
 
 For more information, see the {@link operation/open-document-template-browser-modal} operation.
@@ -114,6 +118,7 @@ This browser can be used by adding the following operation step to your operatio
 ```
 * Use `insertOperationName` to disable the primary button based on the operation state.
 * Use `openDocumentDataProviderName`, `selectDocumentTemplateDataProviderName` and `selectFolderDataProviderName` to override the default data provider properties.
+* Use `openDocumentEnableSearch` and `selectDocumentTemplateEnableSearch` to enable the fulltext search query field in the toolbars.
 * The browser icon and title can be set with the `modalIcon` and `modalTitle` respectively.
 
 For more information, see the {@link operation/open-open-or-create-document-browser-modal} operation.
@@ -134,6 +139,7 @@ This browser can be used by adding the following operation step to your operatio
 
 * Use `insertOperationName` to disable the primary button based on the operation state.
 * Use `selectDocumentTemplateDataProviderName` and `selectFolderDataProviderName` to override the default data provider properties.
+* Use `selectDocumentTemplateEnableSearch` to enable the fulltext search query field in the toolbar.
 * The browser icon and title can be set with the `modalIcon` and `modalTitle` respectively.
 
 For more information, see the {@link operation/open-create-document-form-modal} operation.

--- a/src/data-providers/createDataProviderUsingConfiguredConnectors.js
+++ b/src/data-providers/createDataProviderUsingConfiguredConnectors.js
@@ -39,7 +39,7 @@ define([
 			browseContextDocumentId,
 			options.assetTypes,
 			options.resultTypes,
-			targetFolder.id,
+			options.folderId || targetFolder.id,
 			options.query || null,
 			null,
 			null,
@@ -107,14 +107,16 @@ define([
 			 * @param {object} targetFolder
 			 * @param {boolean} noCache
 			 * @param {object[]} hierarchyItems
+			 * @param {object} [browseParameters]
 			 *
 			 * @return {Promise<{
 			 *   hierarchyItems: string[]
 			 *   items: { id: string, label: string, icon: string, isDisabled: Boolean, externalUrl: string }[]
 			 * }>}
 			 */
-			getFolderContents: function (browseContextDocumentId, targetFolder, noCache, hierarchyItems) {
-				return getFolderContents(options, browseContextDocumentId, targetFolder, noCache, hierarchyItems);
+			getFolderContents: function (browseContextDocumentId, targetFolder, noCache, hierarchyItems, browseParameters) {
+				var optionsForRequest = Object.assign({}, options, browseParameters || {});
+				return getFolderContents(optionsForRequest, browseContextDocumentId, targetFolder, noCache, hierarchyItems);
 			},
 
 			/**

--- a/src/documents/DocumentBrowserModal.jsx.js
+++ b/src/documents/DocumentBrowserModal.jsx.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import {
+	Flex,
 	Button,
 	Modal,
 	ModalBody,
@@ -21,6 +22,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserSearchBar from '../shared/ModalBrowserSearchBar.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
@@ -32,6 +34,10 @@ const stateLabels = {
 	browseError: {
 		title: t('Can’t open this folder'),
 		message: t('FontoXML can’t open this folder. You can try again, or try a different folder.')
+	},
+	searchError: {
+		title: t('Could not perform search'),
+		message: t('FontoXML can’t complete your search query. You can try a different query.')
 	},
 	empty: {
 		title: t('No results'),
@@ -174,10 +180,12 @@ class DocumentBrowserModal extends Component {
 			items,
 			onItemIsErrored,
 			onItemSelect,
+			onSearchRequest,
 			onViewModeChange,
 			refreshItems,
 			renderModalBodyToolbar,
 			request,
+			searchParameters,
 			selectedItem,
 			viewMode
 		} = this.props;
@@ -204,10 +212,22 @@ class DocumentBrowserModal extends Component {
 								/>
 							)}
 
-							<ModalBrowserListOrGridViewMode
-								onViewModeChange={onViewModeChange}
-								viewMode={viewMode}
-							/>
+							<Flex flex="none" spaceSize="m">
+								{!!this.props.data.enableSearch && (
+									<ModalBrowserSearchBar
+										browseContextDocumentId={browseContextDocumentId}
+										onSearchRequest={onSearchRequest}
+										refreshItems={refreshItems}
+										request={request}
+										searchParameters={searchParameters}
+									/>
+								)}
+
+								<ModalBrowserListOrGridViewMode
+									onViewModeChange={onViewModeChange}
+									viewMode={viewMode}
+								/>
+							</Flex>
 						</ModalContentToolbar>
 
 						<ModalContent flexDirection="row">
@@ -227,16 +247,16 @@ class DocumentBrowserModal extends Component {
 							</ModalContent>
 
 							{selectedItem &&
-							selectedItem.type !== 'folder' && (
-								<ModalContent flexDirection="column">
-									<DocumentPreview
-										onLoadIsDone={this.handleLoadIsDone}
-										onItemIsErrored={onItemIsErrored}
-										selectedItem={selectedItem}
-										stateLabels={stateLabels}
-									/>
-								</ModalContent>
-							)}
+								selectedItem.type !== 'folder' && (
+									<ModalContent flexDirection="column">
+										<DocumentPreview
+											onLoadIsDone={this.handleLoadIsDone}
+											onItemIsErrored={onItemIsErrored}
+											selectedItem={selectedItem}
+											stateLabels={stateLabels}
+										/>
+									</ModalContent>
+								)}
 						</ModalContent>
 					</ModalContent>
 				</ModalBody>

--- a/src/documents/DocumentTemplateBrowserModal.jsx.js
+++ b/src/documents/DocumentTemplateBrowserModal.jsx.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import {
+	Flex,
 	Button,
 	Modal,
 	ModalBody,
@@ -20,6 +21,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserSearchBar from '../shared/ModalBrowserSearchBar.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
@@ -31,6 +33,10 @@ const stateLabels = {
 	browseError: {
 		title: t('Can’t open this folder'),
 		message: null
+	},
+	searchError: {
+		title: t('Could not perform search'),
+		message: t('FontoXML can’t complete your search query. You can try a different query.')
 	},
 	empty: {
 		title: t('No results'),
@@ -127,15 +133,22 @@ class DocumentTemplateBrowserModal extends Component {
 	render() {
 		const {
 			cancelModal,
-			data: { browseContextDocumentId, modalIcon, modalPrimaryButtonLabel, modalTitle },
+			data: {
+				browseContextDocumentId,
+				modalIcon,
+				modalPrimaryButtonLabel,
+				modalTitle
+			},
 			hierarchyItems,
 			isSubmitButtonDisabled,
 			items,
 			onItemIsErrored,
 			onItemSelect,
+			onSearchRequest,
 			onViewModeChange,
 			refreshItems,
 			request,
+			searchParameters,
 			selectedItem,
 			viewMode
 		} = this.props;
@@ -159,10 +172,22 @@ class DocumentTemplateBrowserModal extends Component {
 								/>
 							)}
 
-							<ModalBrowserListOrGridViewMode
-								onViewModeChange={onViewModeChange}
-								viewMode={viewMode}
-							/>
+							<Flex flex="none" spaceSize="m">
+								{!!this.props.data.enableSearch && (
+									<ModalBrowserSearchBar
+										browseContextDocumentId={browseContextDocumentId}
+										onSearchRequest={onSearchRequest}
+										refreshItems={refreshItems}
+										request={request}
+										searchParameters={searchParameters}
+									/>
+								)}
+
+								<ModalBrowserListOrGridViewMode
+									onViewModeChange={onViewModeChange}
+									viewMode={viewMode}
+								/>
+							</Flex>
 						</ModalContentToolbar>
 
 						<ModalContent flexDirection="row">

--- a/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
+++ b/src/documents/DocumentWithLinkSelectorBrowserModal.jsx.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import React, { Component } from 'react';
 
 import {
+	Flex,
 	Button,
 	Modal,
 	ModalBody,
@@ -21,6 +22,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserSearchBar from '../shared/ModalBrowserSearchBar.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
 
@@ -32,6 +34,10 @@ const stateLabels = {
 	browseError: {
 		title: t('Can’t open this folder'),
 		message: t('FontoXML can’t open this folder. You can try again, or try a different folder.')
+	},
+	searchError: {
+		title: t('Could not perform search'),
+		message: t('FontoXML can’t complete your search query. You can try a different query.')
 	},
 	empty: {
 		title: t('No results'),
@@ -133,9 +139,11 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 			items,
 			onItemIsErrored,
 			onItemSelect,
+			onSearchRequest,
 			onViewModeChange,
 			refreshItems,
 			request,
+			searchParameters,
 			selectedItem,
 			viewMode
 		} = this.props;
@@ -159,10 +167,22 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 								/>
 							)}
 
-							<ModalBrowserListOrGridViewMode
-								onViewModeChange={onViewModeChange}
-								viewMode={viewMode}
-							/>
+							<Flex flex="none" spaceSize="m">
+								{!!this.props.data.enableSearch && (
+									<ModalBrowserSearchBar
+										browseContextDocumentId={browseContextDocumentId}
+										onSearchRequest={onSearchRequest}
+										refreshItems={refreshItems}
+										request={request}
+										searchParameters={searchParameters}
+									/>
+								)}
+
+								<ModalBrowserListOrGridViewMode
+									onViewModeChange={onViewModeChange}
+									viewMode={viewMode}
+								/>
+							</Flex>
 						</ModalContentToolbar>
 
 						<ModalContent flexDirection="row">
@@ -182,18 +202,18 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 							</ModalContent>
 
 							{selectedItem &&
-							selectedItem.id &&
-							selectedItem.type !== 'folder' && (
-								<ModalContent flexDirection="column">
-									<DocumentWithLinkSelectorPreview
-										linkableElementsQuery={linkableElementsQuery}
-										onItemIsErrored={onItemIsErrored}
-										onItemSelect={onItemSelect}
-										selectedItem={selectedItem}
-										stateLabels={stateLabels}
-									/>
-								</ModalContent>
-							)}
+								selectedItem.id &&
+								selectedItem.type !== 'folder' && (
+									<ModalContent flexDirection="column">
+										<DocumentWithLinkSelectorPreview
+											linkableElementsQuery={linkableElementsQuery}
+											onItemIsErrored={onItemIsErrored}
+											onItemSelect={onItemSelect}
+											selectedItem={selectedItem}
+											stateLabels={stateLabels}
+										/>
+									</ModalContent>
+								)}
 						</ModalContent>
 					</ModalContent>
 				</ModalBody>

--- a/src/documents/FolderBrowserModal.jsx.js
+++ b/src/documents/FolderBrowserModal.jsx.js
@@ -30,6 +30,10 @@ const stateLabels = {
 		title: t('Can’t open this folder'),
 		message: t('FontoXML can’t open this folder. You can try again, or try a different folder.')
 	},
+	searchError: {
+		title: t('Could not perform search'),
+		message: t('FontoXML can’t complete your search query. You can try a different query.')
+	},
 	empty: {
 		title: t('No results'),
 		message: null

--- a/src/images/ImageBrowserModal.jsx.js
+++ b/src/images/ImageBrowserModal.jsx.js
@@ -22,6 +22,7 @@ import ModalBrowserHierarchyBreadcrumbs from '../shared/ModalBrowserHierarchyBre
 import ModalBrowserListOrGridViewMode, {
 	VIEWMODES
 } from '../shared/ModalBrowserListOrGridViewMode.jsx';
+import ModalBrowserSearchBar from '../shared/ModalBrowserSearchBar.jsx';
 import ModalBrowserUploadButton from '../shared/ModalBrowserUploadButton.jsx';
 import withInsertOperationNameCapabilities from '../withInsertOperationNameCapabilities.jsx';
 import withModularBrowserCapabilities from '../withModularBrowserCapabilities.jsx';
@@ -34,6 +35,10 @@ const stateLabels = {
 	browseError: {
 		title: t('Can’t open this folder'),
 		message: t('FontoXML can’t open this folder. You can try again, or try a different folder.')
+	},
+	searchError: {
+		title: t('Could not perform search'),
+		message: t('FontoXML can’t complete your search query. You can try a different query.')
 	},
 	empty: {
 		title: t('No results'),
@@ -138,10 +143,12 @@ class ImageBrowserModal extends Component {
 			isSubmitButtonDisabled,
 			items,
 			onItemSelect,
+			onSearchRequest,
 			onUploadFileSelect,
 			onViewModeChange,
 			refreshItems,
 			request,
+			searchParameters,
 			selectedItem,
 			viewMode
 		} = this.props;
@@ -170,10 +177,21 @@ class ImageBrowserModal extends Component {
 									browseContextDocumentId={browseContextDocumentId}
 									dataProviderName={dataProviderName}
 									hierarchyItems={hierarchyItems}
-									request={request}
-									uploadErrorMessages={uploadErrorMessages}
 									onUploadFileSelect={onUploadFileSelect}
+									request={request}
+									searchParameters={searchParameters}
+									uploadErrorMessages={uploadErrorMessages}
 								/>
+
+								{!!this.props.data.enableSearch && (
+									<ModalBrowserSearchBar
+										browseContextDocumentId={browseContextDocumentId}
+										onSearchRequest={onSearchRequest}
+										refreshItems={refreshItems}
+										request={request}
+										searchParameters={searchParameters}
+									/>
+								)}
 
 								<ModalBrowserListOrGridViewMode
 									onViewModeChange={onViewModeChange}
@@ -183,15 +201,15 @@ class ImageBrowserModal extends Component {
 						</ModalContentToolbar>
 
 						{request.type === 'upload' &&
-						request.error && (
-							<ModalContent flex="none" paddingSize="m">
-								<Toast
-									connotation="error"
-									icon="exclamation-triangle"
-									content={request.error}
-								/>
-							</ModalContent>
-						)}
+							request.error && (
+								<ModalContent flex="none" paddingSize="m">
+									<Toast
+										connotation="error"
+										icon="exclamation-triangle"
+										content={request.error}
+									/>
+								</ModalContent>
+							)}
 
 						<ModalContent flexDirection="row">
 							<ModalContent flexDirection="column">
@@ -211,14 +229,14 @@ class ImageBrowserModal extends Component {
 							</ModalContent>
 
 							{selectedItem &&
-							selectedItem.type !== 'folder' && (
-								<ModalContent flexDirection="column">
-									<ImagePreview
-										selectedItem={selectedItem}
-										stateLabels={stateLabels}
-									/>
-								</ModalContent>
-							)}
+								selectedItem.type !== 'folder' && (
+									<ModalContent flexDirection="column">
+										<ImagePreview
+											selectedItem={selectedItem}
+											stateLabels={stateLabels}
+										/>
+									</ModalContent>
+								)}
 						</ModalContent>
 					</ModalContent>
 				</ModalBody>

--- a/src/operations.json
+++ b/src/operations.json
@@ -37,6 +37,14 @@
 					]
 				},
 				{
+					"name": "enableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar. ",
+						"Defaults to false."
+					]
+				},
+				{
 					"name": "insertOperationName",
 					"type": "string",
 					"description": [
@@ -95,6 +103,7 @@
 		"initialData": {
 			"dataProviderName": "dataProviderUsingConfiguredConnectorsForDocuments",
 			"documentId": null,
+			"enableSearch": false,
 			"linkableElementsQuery": "//*[@id]",
 			"modalPrimaryButtonLabel": null,
 			"modalTitle": null,
@@ -108,6 +117,7 @@
 					"browseContextDocumentId": "{{browseContextDocumentId}}",
 					"dataProviderName": "{{dataProviderName}}",
 					"documentId": "{{documentId}}",
+					"enableSearch": "{{enableSearch}}",
 					"linkableElementsQuery": "{{linkableElementsQuery}}",
 					"modalPrimaryButtonLabel": "{{modalPrimaryButtonLabel}}",
 					"modalTitle": "{{modalTitle}}",
@@ -144,6 +154,14 @@
 						"(Optional) Use this property when the default data provider can not be used. ",
 						"Set your own properties for your modal with {@link dataProviders} and use ",
 						"the set name in the operation data."
+					]
+				},
+				{
+					"name": "enableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar. ",
+						"Defaults to false."
 					]
 				},
 				{
@@ -190,6 +208,7 @@
 		},
 		"initialData": {
 			"dataProviderName": "dataProviderUsingConfiguredConnectorsForImages",
+			"enableSearch": false,
 			"modalPrimaryButtonLabel": null,
 			"modalTitle": null,
 			"selectedImageId": null
@@ -201,6 +220,7 @@
 				"data": {
 					"browseContextDocumentId": "{{browseContextDocumentId}}",
 					"dataProviderName": "{{dataProviderName}}",
+					"enableSearch": "{{enableSearch}}",
 					"modalPrimaryButtonLabel": "{{modalPrimaryButtonLabel}}",
 					"modalTitle": "{{modalTitle}}",
 					"selectedImageId": "{{selectedImageId}}"
@@ -244,6 +264,14 @@
 					"type": "DocumentId",
 					"description": [
 						"(Optional) Can be used to open the document browser with a document preselected."
+					]
+				},
+				{
+					"name": "enableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar. ",
+						"Defaults to false."
 					]
 				},
 				{
@@ -294,6 +322,7 @@
 		"initialData": {
 			"dataProviderName": "dataProviderUsingConfiguredConnectorsForDocuments",
 			"documentId": null,
+			"enableSearch": false,
 			"isCancelable": true,
 			"modalPrimaryButtonLabel": null,
 			"modalTitle": null
@@ -307,6 +336,7 @@
 					"isCancelable": "{{isCancelable}}",
 					"dataProviderName": "{{dataProviderName}}",
 					"documentId": "{{documentId}}",
+					"enableSearch": "{{enableSearch}}",
 					"modalPrimaryButtonLabel": "{{modalPrimaryButtonLabel}}",
 					"modalTitle": "{{modalTitle}}"
 				}
@@ -339,6 +369,14 @@
 						"(Optional) Use this property when the default data provider can not be used. ",
 						"Set your own properties for your modal with {@link dataProviders} and use ",
 						"the set name in the operation data."
+					]
+				},
+				{
+					"name": "enableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar. ",
+						"Defaults to false."
 					]
 				},
 				{
@@ -378,6 +416,7 @@
 		},
 		"initialData": {
 			"dataProviderName": "dataProviderUsingConfiguredConnectorsForDocumentTemplates",
+			"enableSearch": false,
 			"modalPrimaryButtonLabel": null,
 			"modalTitle": null
 		},
@@ -387,6 +426,7 @@
 				"type": "modal/DocumentTemplateBrowserModal",
 				"data": {
 					"browseContextDocumentId": "{{browseContextDocumentId}}",
+					"enableSearch": "{{enableSearch}}",
 					"dataProviderName": "{{dataProviderName}}",
 					"modalPrimaryButtonLabel": "{{modalPrimaryButtonLabel}}",
 					"modalTitle": "{{modalTitle}}"
@@ -430,6 +470,14 @@
 					]
 				},
 				{
+					"name": "openDocumentEnableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar for the",
+						"document browse modal. Defaults to false."
+					]
+				},
+				{
 					"name": "selectDocumentTemplateDataProviderName",
 					"type": "string",
 					"desription": [
@@ -437,6 +485,14 @@
 						"new document. Use this property when the default data provider can not be used. ",
 						"Set your own properties for your modal with {@link dataProviders} and use ",
 						"the set name in the operation data."
+					]
+				},
+				{
+					"name": "selectDocumentTemplateEnableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar for the",
+						"document template modal. Defaults to false."
 					]
 				},
 				{
@@ -509,7 +565,9 @@
 			"isCancelable": true,
 			"modalTitle": null,
 			"openDocumentDataProviderName": "dataProviderUsingConfiguredConnectorsForDocuments",
+			"openDocumentEnableSearch": false,
 			"selectDocumentTemplateDataProviderName": "dataProviderUsingConfiguredConnectorsForDocumentTemplates",
+			"selectDocumentTemplateEnableSearch": false,
 			"selectFolderDataProviderName": "dataProviderUsingConfiguredConnectorsForDocumentFolders"
 		},
 		"steps": [
@@ -521,7 +579,9 @@
 					"isCancelable": "{{isCancelable}}",
 					"modalTitle": "{{modalTitle}}",
 					"openDocumentDataProviderName": "{{openDocumentDataProviderName}}",
+					"openDocumentEnableSearch": "{{openDocumentEnableSearch}}",
 					"selectDocumentTemplateDataProviderName": "{{selectDocumentTemplateDataProviderName}}",
+					"selectDocumentTemplateEnableSearch": "{{selectDocumentTemplateEnableSearch}}",
 					"selectFolderDataProviderName": "{{selectFolderDataProviderName}}"
 				}
 			}
@@ -558,6 +618,14 @@
 						"new document. Use this property when the default data provider can not be used. ",
 						"Set your own properties for your modal with {@link dataProviders} and use ",
 						"the set name in the operation data."
+					]
+				},
+				{
+					"name": "selectDocumentTemplateEnableSearch",
+					"type": "boolean",
+					"description": [
+						"(Optional) Can be used to add an fulltext search field to the toolbar for the",
+						"document template modal. Defaults to false."
 					]
 				},
 				{
@@ -620,6 +688,7 @@
 			"isCancelable": true,
 			"modalTitle": null,
 			"selectDocumentTemplateDataProviderName": "dataProviderUsingConfiguredConnectorsForDocumentTemplates",
+			"selectDocumentTemplateEnableSearch": false,
 			"selectFolderDataProviderName": "dataProviderUsingConfiguredConnectorsForDocumentFolders"
 		},
 		"steps": [
@@ -631,6 +700,7 @@
 					"isCancelable": "{{isCancelable}}",
 					"modalTitle": "{{modalTitle}}",
 					"selectDocumentTemplateDataProviderName": "{{selectDocumentTemplateDataProviderName}}",
+					"selectDocumentTemplateEnableSearch": "{{selectDocumentTemplateEnableSearch}}",
 					"selectFolderDataProviderName": "{{selectFolderDataProviderName}}"
 				}
 			}

--- a/src/shared/ModalBrowserFileAndFolderResultList.jsx.js
+++ b/src/shared/ModalBrowserFileAndFolderResultList.jsx.js
@@ -23,6 +23,10 @@ class ModalBrowserFileAndFolderResultList extends Component {
 				title: PropTypes.string,
 				message: PropTypes.string
 			}).isRequired,
+			searchError: PropTypes.shape({
+				title: PropTypes.string,
+				message: PropTypes.string
+			}).isRequired,
 			empty: PropTypes.shape({
 				title: PropTypes.string,
 				message: PropTypes.string
@@ -65,7 +69,10 @@ class ModalBrowserFileAndFolderResultList extends Component {
 			viewMode
 		} = this.props;
 
-		if ((request.type === 'browse' || request.type === 'upload') && request.busy) {
+		if (
+			(request.type === 'browse' || request.type === 'search' || request.type === 'upload') &&
+			request.busy
+		) {
 			return (
 				<StateMessage paddingSize="m" visual={<SpinnerIcon />} {...stateLabels.loading} />
 			);
@@ -78,6 +85,17 @@ class ModalBrowserFileAndFolderResultList extends Component {
 					paddingSize="m"
 					visual="exclamation-triangle"
 					{...stateLabels.browseError}
+				/>
+			);
+		}
+
+		if (request.type === 'search' && request.error) {
+			return (
+				<StateMessage
+					connotation="warning"
+					paddingSize="m"
+					visual="exclamation-triangle"
+					{...stateLabels.searchError}
 				/>
 			);
 		}

--- a/src/shared/ModalBrowserHierarchyBreadcrumbs.jsx.js
+++ b/src/shared/ModalBrowserHierarchyBreadcrumbs.jsx.js
@@ -62,7 +62,10 @@ class ModalBrowserHierarchyBreadcrumbs extends Component {
 		return (
 			<Breadcrumbs
 				isDisabled={
-					(request.type === 'browse' || request.type === 'upload') && request.busy
+					(request.type === 'browse' ||
+						request.type === 'search' ||
+						request.type === 'upload') &&
+					request.busy
 				}
 				items={this.props.hierarchyItems}
 				renderBreadcrumbItem={this.renderBreadcrumbItem}

--- a/src/shared/ModalBrowserSearchBar.jsx.js
+++ b/src/shared/ModalBrowserSearchBar.jsx.js
@@ -1,0 +1,89 @@
+import PropTypes from 'prop-types';
+import React, { Component } from 'react';
+
+import { SearchInput } from 'fds/components';
+
+export default class ModalBrowserSearchBar extends Component {
+	static defaultProps = {
+		browseContextDocumentId: null,
+		searchParameters: null
+	};
+
+	static propTypes = {
+		browseContextDocumentId: PropTypes.string,
+
+		// from withModularBrowserCapabilities
+		onSearchRequest: PropTypes.func.isRequired,
+		refreshItems: PropTypes.func.isRequired,
+		request: PropTypes.object.isRequired,
+		searchParameters: PropTypes.object
+	};
+
+	state = {
+		fulltext: ''
+	};
+
+	onFulltextChange = fulltext => {
+		this.setState({
+			fulltext
+		});
+	};
+
+	requestSearch(query) {
+		const { browseContextDocumentId, onSearchRequest } = this.props;
+
+		const searchParameters = {
+			resultTypes: ['file'],
+			folderId: null,
+			query,
+			offset: 0
+		};
+
+		return onSearchRequest(browseContextDocumentId, searchParameters);
+	}
+
+	onSearchSubmit = () => {
+		const { browseContextDocumentId, refreshItems } = this.props;
+		const { fulltext } = this.state;
+
+		if (!fulltext) {
+			// No query, so go back to normal view.
+			refreshItems(browseContextDocumentId, { id: null });
+			return;
+		}
+
+		this.requestSearch({
+			fulltext
+		});
+	};
+
+	componentWillReceiveProps(nextProps) {
+		if (nextProps.searchParameters && nextProps.searchParameters.query) {
+			// Update search input to current state.
+			if (nextProps.searchParameters.query.fulltext !== this.state.fulltext) {
+				this.setState({
+					fulltext: nextProps.searchParameters.query.fulltext
+				});
+			}
+		} else {
+			// Clear search input.
+			this.setState({
+				fulltext: ''
+			});
+		}
+	}
+
+	render() {
+		const { request } = this.props;
+		const { fulltext } = this.state;
+
+		return (
+			<SearchInput
+				isDisabled={!!request && !!request.busy}
+				value={fulltext}
+				onChange={this.onFulltextChange}
+				onSubmitButtonClick={this.onSearchSubmit}
+			/>
+		);
+	}
+}

--- a/src/shared/ModalBrowserUploadButton.jsx.js
+++ b/src/shared/ModalBrowserUploadButton.jsx.js
@@ -6,6 +6,8 @@ import t from 'fontoxml-localization/t';
 
 import dataProviders from '../dataProviders';
 
+const disabledReasonOnSearch = t('Upload is disabled while searching.');
+
 class ModalBrowserUploadButton extends PureComponent {
 	static defaultProps = {
 		hierarchyItems: [],
@@ -23,7 +25,8 @@ class ModalBrowserUploadButton extends PureComponent {
 		// from withModularBrowserCapabilities
 		hierarchyItems: PropTypes.array,
 		onUploadFileSelect: PropTypes.func.isRequired,
-		request: PropTypes.object.isRequired
+		request: PropTypes.object.isRequired,
+		searchParameters: PropTypes.object
 	};
 
 	dataProvider = dataProviders.get(this.props.dataProviderName);
@@ -36,18 +39,23 @@ class ModalBrowserUploadButton extends PureComponent {
 		);
 
 	render() {
-		const { hierarchyItems, request } = this.props;
+		const { hierarchyItems, request, searchParameters } = this.props;
 
 		const isUploading = request.type === 'upload' && request.busy;
-		const isLoading = isUploading || (request.type === 'browse' && request.busy);
+		const isLoading =
+			isUploading ||
+			((request.type === 'browse' || request.type === 'search') && request.busy);
 
 		const lastLoadedFolder =
 			hierarchyItems.length > 0 ? hierarchyItems[hierarchyItems.length - 1] : null;
 
+		const isSearching = !!searchParameters;
+
 		return (
 			<SelectFileButton
 				label={t('Upload')}
-				isDisabled={isLoading || lastLoadedFolder === null}
+				isDisabled={isLoading || lastLoadedFolder === null || isSearching}
+				tooltipContent={isSearching && disabledReasonOnSearch}
 				mimeTypesToAccept={this.dataProvider.getUploadOptions().mimeTypesToAccept}
 				icon="upload"
 				iconAfter={isUploading ? 'spinner' : null}

--- a/src/stacks/CreateDocumentModalStack.jsx.js
+++ b/src/stacks/CreateDocumentModalStack.jsx.js
@@ -57,6 +57,7 @@ class CreateDocumentFormModalStack extends Component {
 				modalIcon,
 				modalTitle,
 				selectDocumentTemplateDataProviderName,
+				selectDocumentTemplateEnableSearch,
 				selectFolderDataProviderName
 			},
 			cancelModal,
@@ -86,6 +87,7 @@ class CreateDocumentFormModalStack extends Component {
 						data={{
 							browseContextDocumentId: null,
 							dataProviderName: selectDocumentTemplateDataProviderName,
+							enableSearch: selectDocumentTemplateEnableSearch,
 							modalTitle: t('Select a template for your document')
 						}}
 						remoteDocumentId={selectedDocumentTemplate.remoteDocumentId}

--- a/src/stacks/OpenOrCreateDocumentModalStack.jsx.js
+++ b/src/stacks/OpenOrCreateDocumentModalStack.jsx.js
@@ -87,7 +87,9 @@ class OpenOrCreateDocumentModalStack extends Component {
 				modalIcon,
 				modalTitle,
 				openDocumentDataProviderName,
+				openDocumentEnableSearch,
 				selectDocumentTemplateDataProviderName,
+				selectDocumentTemplateEnableSearch,
 				selectFolderDataProviderName
 			},
 			cancelModal,
@@ -104,6 +106,7 @@ class OpenOrCreateDocumentModalStack extends Component {
 						data={{
 							browseContextDocumentId,
 							dataProviderName: openDocumentDataProviderName,
+							enableSearch: openDocumentEnableSearch,
 							insertOperationName,
 							isCancelable,
 							modalIcon,
@@ -139,6 +142,7 @@ class OpenOrCreateDocumentModalStack extends Component {
 						data={{
 							browseContextDocumentId: null,
 							dataProviderName: selectDocumentTemplateDataProviderName,
+							enableSearch: selectDocumentTemplateEnableSearch,
 							modalTitle: t('Select a template for your document')
 						}}
 						remoteDocumentId={selectedDocumentTemplate.remoteDocumentId}


### PR DESCRIPTION
This pull request implements an optional simple fulltext search query field for most browse modals.

### What does it do
Adds an optional enableSearch property to the operations for the document, document template, document with link selector, image modal operations; A `selectDocumentTemplateEnableSearch` property to the open create document modal operation; And `openDocumentEnableSearch` and `selectDocumentTemplateEnableSearch` to the open open or create document modal operation.

When the `*enableSearch` property is set to `true`, a search input is show in the top toolbar, left to the view mode buttons (and right to the upload button in the image modal).

### Choices
* When search is active, the upload button is disabled, showing a tooltip as to why.
* The breadcrumb is set to the root folder only.
* The search input is only applied on input submit, not as you type.

### What could be better
* A button to clear the search input (Now you can either clear the input field text and submit, or click on the breadcrumb item
* Input focus state bug

![image](https://user-images.githubusercontent.com/6639278/42379330-a4649562-812a-11e8-84b0-d62317442d35.png)
