### PR TITLE
DEV-2211 Pass the referrerDocumentId through to FxDocumentLoader when previewing

### DIFF
--- a/src/documents/DocumentBrowserModal.jsx
+++ b/src/documents/DocumentBrowserModal.jsx
@@ -235,6 +235,7 @@ class DocumentBrowserModal extends Component {
 										onItemIsErrored={onItemIsErrored}
 										onLoadIsDone={this.handleLoadIsDone}
 										selectedItem={selectedItem}
+											referrerDocumentId={browseContextDocumentId}
 										stateLabels={stateLabels}
 									/>
 								</ModalContent>

--- a/src/documents/DocumentPreview.jsx
+++ b/src/documents/DocumentPreview.jsx
@@ -12,7 +12,8 @@ class DocumentPreview extends Component {
 	static defaultProps = {
 		onLoadIsDone: _documentId => {},
 		onItemIsErrored: _item => {},
-		selectedItem: null
+		selectedItem: null,
+		referrerDocumentId: null
 	};
 
 	static propTypes = {
@@ -24,15 +25,17 @@ class DocumentPreview extends Component {
 				message: PropTypes.string
 			}).isRequired
 		}).isRequired,
-		selectedItem: PropTypes.object
+		selectedItem: PropTypes.object,
+		referrerDocumentId: PropTypes.string
 	};
 
 	render() {
-		const { stateLabels, selectedItem } = this.props;
+		const { stateLabels, selectedItem, referrerDocumentId } = this.props;
 
 		return (
 			<FxDocumentLoader
 				remoteId={selectedItem.id}
+				referrerDocumentId={referrerDocumentId}
 				onError={this.props.onItemIsErrored}
 				onLoadIsDone={this.props.onLoadIsDone}
 			>

--- a/src/documents/DocumentTemplateBrowserModal.jsx
+++ b/src/documents/DocumentTemplateBrowserModal.jsx
@@ -198,6 +198,7 @@ class DocumentTemplateBrowserModal extends Component {
 										onItemIsErrored={onItemIsErrored}
 										onLoadIsDone={this.handleLoadIsDone}
 										selectedItem={selectedItem}
+											referrerDocumentId={browseContextDocumentId}
 										stateLabels={stateLabels}
 									/>
 								</ModalContent>

--- a/src/documents/DocumentWithLinkSelectorBrowserModal.jsx
+++ b/src/documents/DocumentWithLinkSelectorBrowserModal.jsx
@@ -193,6 +193,7 @@ class DocumentWithLinkSelectorBrowserModal extends Component {
 										onItemSelect={onItemSelect}
 										onLoadIsDone={this.handleLoadIsDone}
 										selectedItem={selectedItem}
+											referrerDocumentId={browseContextDocumentId}
 										stateLabels={stateLabels}
 									/>
 								</ModalContent>

--- a/src/documents/DocumentWithLinkSelectorPreview.jsx
+++ b/src/documents/DocumentWithLinkSelectorPreview.jsx
@@ -14,7 +14,8 @@ class DocumentWithLinkSelectorPreview extends Component {
 	static defaultProps = {
 		onItemIsErrored: _item => {},
 		onLoadIsDone: _documentId => {},
-		selectedItem: null
+		selectedItem: null,
+		referrerDocumentId: null
 	};
 
 	static propTypes = {
@@ -23,6 +24,7 @@ class DocumentWithLinkSelectorPreview extends Component {
 		onItemSelect: PropTypes.func.isRequired,
 		onLoadIsDone: PropTypes.func,
 		selectedItem: PropTypes.object,
+		referrerDocumentId: PropTypes.string,
 		stateLabels: PropTypes.shape({
 			loadingPreview: PropTypes.shape({
 				title: PropTypes.string,
@@ -60,11 +62,12 @@ class DocumentWithLinkSelectorPreview extends Component {
 		this.props.onItemSelect({ ...this.props.selectedItem, nodeId });
 
 	render() {
-		const { linkableElementsQuery, stateLabels, selectedItem } = this.props;
+		const { linkableElementsQuery, stateLabels, selectedItem, referrerDocumentId } = this.props;
 
 		return (
 			<FxDocumentLoader
 				remoteId={selectedItem.id}
+				referrerDocumentId={referrerDocumentId}
 				onError={this.props.onItemIsErrored}
 				onLoadIsDone={this.handleLoadIsDone}
 			>


### PR DESCRIPTION
If `FxDocumentLoader` would accept the `referrerDocumentId` prop (this is a change in the proprietary code of Fonto), then the CMS browser should pass this value on. Documents and document templates can then be correctly previewed in cases where the response items in `POST /browse` are relative references.